### PR TITLE
add benchmark for differen num of rows

### DIFF
--- a/dbms/src/Storages/Transaction/tests/bench_region_block_reader.cpp
+++ b/dbms/src/Storages/Transaction/tests/bench_region_block_reader.cpp
@@ -29,7 +29,6 @@ protected:
     Int64 handle_value = 100;
     UInt8 del_mark_value = 0;
     UInt64 version_value = 100;
-    size_t rows = 100;
 
     RegionDataReadInfoList data_list_read;
     std::unordered_map<ColumnID, Field> fields_map;
@@ -47,7 +46,7 @@ protected:
         fields_map.clear();
     }
 
-    void encodeColumns(TableInfo & table_info, std::vector<Field> & fields, RowEncodeVersion row_version)
+    void encodeColumns(TableInfo & table_info, std::vector<Field> & fields, RowEncodeVersion row_version, size_t num_rows)
     {
         // for later check
         std::unordered_map<String, size_t> column_name_columns_index_map;
@@ -98,7 +97,7 @@ protected:
             throw Exception("Unknown row format " + std::to_string(row_version), ErrorCodes::LOGICAL_ERROR);
         }
         auto row_value = std::make_shared<const TiKVValue>(std::move(value_buf.str()));
-        for (size_t i = 0; i < rows; i++)
+        for (size_t i = 0; i < num_rows; i++)
             data_list_read.emplace_back(pk, del_mark_value, version_value, row_value);
     }
 
@@ -126,8 +125,9 @@ protected:
 BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, CommonHandleWithCheck)
 (benchmark::State & state)
 {
+    size_t num_rows = state.range(0);
     auto [table_info, fields] = getNormalTableInfoFields({2, 3, 4}, true);
-    encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
+    encodeColumns(table_info, fields, RowEncodeVersion::RowV2, num_rows);
     auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info);
     for (auto _ : state)
     {
@@ -137,8 +137,9 @@ BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, CommonHandleWithCheck)
 BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, CommonHandleWithoutCheck)
 (benchmark::State & state)
 {
+    size_t num_rows = state.range(0);
     auto [table_info, fields] = getNormalTableInfoFields({2, 3, 4}, true);
-    encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
+    encodeColumns(table_info, fields, RowEncodeVersion::RowV2, num_rows);
     auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info);
     for (auto _ : state)
     {
@@ -149,8 +150,9 @@ BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, CommonHandleWithoutCheck)
 BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsNotHandleWithCheck)
 (benchmark::State & state)
 {
+    size_t num_rows = state.range(0);
     auto [table_info, fields] = getNormalTableInfoFields({EXTRA_HANDLE_COLUMN_ID}, false);
-    encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
+    encodeColumns(table_info, fields, RowEncodeVersion::RowV2, num_rows);
     auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info);
     for (auto _ : state)
     {
@@ -160,8 +162,9 @@ BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsNotHandleWithCheck)
 BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsNotHandleWithoutCheck)
 (benchmark::State & state)
 {
+    size_t num_rows = state.range(0);
     auto [table_info, fields] = getNormalTableInfoFields({EXTRA_HANDLE_COLUMN_ID}, false);
-    encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
+    encodeColumns(table_info, fields, RowEncodeVersion::RowV2, num_rows);
     auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info);
     for (auto _ : state)
     {    
@@ -172,8 +175,9 @@ BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsNotHandleWithoutCheck)
 BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsHandleWithCheck)
 (benchmark::State & state)
 {
+    size_t num_rows = state.range(0);
     auto [table_info, fields] = getNormalTableInfoFields({2}, false);
-    encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
+    encodeColumns(table_info, fields, RowEncodeVersion::RowV2, num_rows);
     auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info);
     for (auto _ : state)
     {
@@ -183,8 +187,9 @@ BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsHandleWithCheck)
 BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsHandleWithoutCheck)
 (benchmark::State & state)
 {   
+    size_t num_rows = state.range(0);
     auto [table_info, fields] = getNormalTableInfoFields({2}, false);
-    encodeColumns(table_info, fields, RowEncodeVersion::RowV2);
+    encodeColumns(table_info, fields, RowEncodeVersion::RowV2, num_rows);
     auto decoding_schema = getDecodingStorageSchemaSnapshot(table_info);
     for (auto _ : state)
     {
@@ -192,12 +197,12 @@ BENCHMARK_DEFINE_F(RegionBlockReaderBenchTest, PKIsHandleWithoutCheck)
     }
 }
 
-BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsHandleWithCheck)->Iterations(1000);
-BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsHandleWithoutCheck)->Iterations(1000);
-BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, CommonHandleWithCheck)->Iterations(1000);
-BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, CommonHandleWithoutCheck)->Iterations(1000);
-BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsNotHandleWithCheck)->Iterations(1000);
-BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsNotHandleWithoutCheck)->Iterations(1000);
+constexpr size_t num_iterations_test = 1000;
 
-
+BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsHandleWithCheck)->Iterations(num_iterations_test)->Arg(1)->Arg(10)->Arg(100);
+BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsHandleWithoutCheck)->Iterations(num_iterations_test)->Arg(1)->Arg(10)->Arg(100);
+BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, CommonHandleWithCheck)->Iterations(num_iterations_test)->Arg(1)->Arg(10)->Arg(100);
+BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, CommonHandleWithoutCheck)->Iterations(num_iterations_test)->Arg(1)->Arg(10)->Arg(100);
+BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsNotHandleWithCheck)->Iterations(num_iterations_test)->Arg(1)->Arg(10)->Arg(100);
+BENCHMARK_REGISTER_F(RegionBlockReaderBenchTest, PKIsNotHandleWithoutCheck)->Iterations(num_iterations_test)->Arg(1)->Arg(10)->Arg(100);
 }


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

```
>  ./dbms/bench_dbms --benchmark_filter='RegionBlockReaderBenchTest'                                                                                                                                                                                 2022-06-21 20:13:18
[2022/06/21 20:14:01.818 +08:00] [INFO] [BackgroundProcessingPool.cpp:93] ["BackgroundProcessingPool:Create BackgroundProcessingPool with 10 threads"] [thread_id=1]
[2022/06/21 20:14:01.820 +08:00] [INFO] [BackgroundProcessingPool.cpp:93] ["BackgroundProcessingPool:Create BackgroundProcessingPool with 10 threads"] [thread_id=1]
[2022/06/21 20:14:01.822 +08:00] [INFO] [PathCapacityMetrics.cpp:84] ["PathCapacityMetrics:Init capacity [path=/data1/jaysonhuang/tics-k/cmake-build-rel/tmp/] [capacity=0.00 B]"] [thread_id=1]
[2022/06/21 20:14:01.822 +08:00] [INFO] [PageStorageImpl.cpp:41] ["PageStorage:__global__.log PageStorageImpl start. Config{ PageStorage::Config V3 {blob_file_limit_size: 536870912, blob_spacemap_type: 2, blob_cached_fd_size: 100, blob_heavy_gc_valid_rate: 0.200, blob_block_alignment_bytes: 0, wal_roll_size: 2097152, wal_recover_mode: 0, wal_max_persisted_log_files: 4} }"] [thread_id=1]
[2022/06/21 20:14:01.822 +08:00] [INFO] [PageStorageImpl.cpp:41] ["PageStorage:__global__.data PageStorageImpl start. Config{ PageStorage::Config V3 {blob_file_limit_size: 536870912, blob_spacemap_type: 2, blob_cached_fd_size: 100, blob_heavy_gc_valid_rate: 0.200, blob_block_alignment_bytes: 0, wal_roll_size: 2097152, wal_recover_mode: 0, wal_max_persisted_log_files: 4} }"] [thread_id=1]
[2022/06/21 20:14:01.822 +08:00] [INFO] [PageStorageImpl.cpp:41] ["PageStorage:__global__.meta PageStorageImpl start. Config{ PageStorage::Config V3 {blob_file_limit_size: 536870912, blob_spacemap_type: 2, blob_cached_fd_size: 100, blob_heavy_gc_valid_rate: 0.200, blob_block_alignment_bytes: 0, wal_roll_size: 2097152, wal_recover_mode: 0, wal_max_persisted_log_files: 4} }"] [thread_id=1]
[2022/06/21 20:14:01.822 +08:00] [INFO] [BlobStore.cpp:114] ["BlobStore:__global__.log Ignore not blob file [dir=/data1/jaysonhuang/tics-k/cmake-build-rel/tmp/page/log] [file=wal] [err_msg=]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [PageDirectoryFactory.cpp:48] ["PageDirectoryFactory:__global__.log PageDirectory restored [max_page_id=0] [max_applied_ver=0]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [BlobStore.cpp:114] ["BlobStore:__global__.data Ignore not blob file [dir=/data1/jaysonhuang/tics-k/cmake-build-rel/tmp/page/data] [file=wal] [err_msg=]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [PageDirectoryFactory.cpp:48] ["PageDirectoryFactory:__global__.data PageDirectory restored [max_page_id=0] [max_applied_ver=0]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [BlobStore.cpp:114] ["BlobStore:__global__.meta Ignore not blob file [dir=/data1/jaysonhuang/tics-k/cmake-build-rel/tmp/page/meta] [file=wal] [err_msg=]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [PageDirectoryFactory.cpp:48] ["PageDirectoryFactory:__global__.meta PageDirectory restored [max_page_id=0] [max_applied_ver=0]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [TiFlashTestEnv.cpp:79] ["TiFlashTestEnv:Storage mode : 2"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [MinTSOScheduler.cpp:47] ["MinTSOScheduler:thread_hard_limit is 10000, thread_soft_limit is 5000, and active_set_soft_limit is 11 in MinTSOScheduler."] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [PageStorageImpl.cpp:41] ["PageStorage:RegionPersister PageStorageImpl start. Config{ PageStorage::Config V3 {blob_file_limit_size: 536870912, blob_spacemap_type: 2, blob_cached_fd_size: 100, blob_heavy_gc_valid_rate: 0.200, blob_block_alignment_bytes: 0, wal_roll_size: 2097152, wal_recover_mode: 0, wal_max_persisted_log_files: 4} }"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [BlobStore.cpp:114] ["BlobStore:RegionPersister Ignore not blob file [dir=/data1/jaysonhuang/tics-k/cmake-build-rel/tmp/page/kvstore] [file=wal] [err_msg=]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [PageDirectoryFactory.cpp:48] ["PageDirectoryFactory:RegionPersister PageDirectory restored [max_page_id=0] [max_applied_ver=0]"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [RegionPersister.cpp:332] ["RegionPersister:RegionPersister running. Current Run Mode is 2"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [KVStore.cpp:61] ["KVStore:Restored 0 regions"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [RegionTable.cpp:168] ["RegionTable:Start to restore"] [thread_id=1]
[2022/06/21 20:14:01.823 +08:00] [INFO] [RegionTable.cpp:174] ["RegionTable:Restore 0 tables"] [thread_id=1]
2022-06-21T20:14:01+08:00
Running ./dbms/bench_dbms
Run on (40 X 2401.01 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x20)
  L1 Instruction 32 KiB (x20)
  L2 Unified 256 KiB (x20)
  L3 Unified 25600 KiB (x2)
Load Average: 4.12, 4.83, 8.34
-------------------------------------------------------------------------------------------------------------------
Benchmark                                                                         Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------------
RegionBlockReaderBenchTest/PKIsHandleWithCheck/1/iterations:1000               3451 ns         3451 ns         1000
RegionBlockReaderBenchTest/PKIsHandleWithCheck/10/iterations:1000              5671 ns         5671 ns         1000
RegionBlockReaderBenchTest/PKIsHandleWithCheck/100/iterations:1000            31444 ns        31445 ns         1000
RegionBlockReaderBenchTest/PKIsHandleWithoutCheck/1/iterations:1000            3147 ns         3148 ns         1000
RegionBlockReaderBenchTest/PKIsHandleWithoutCheck/10/iterations:1000           5829 ns         5829 ns         1000
RegionBlockReaderBenchTest/PKIsHandleWithoutCheck/100/iterations:1000         32280 ns        32282 ns         1000
RegionBlockReaderBenchTest/CommonHandleWithCheck/1/iterations:1000             3357 ns         3357 ns         1000
RegionBlockReaderBenchTest/CommonHandleWithCheck/10/iterations:1000            6612 ns         6613 ns         1000
RegionBlockReaderBenchTest/CommonHandleWithCheck/100/iterations:1000          35033 ns        35035 ns         1000
RegionBlockReaderBenchTest/CommonHandleWithoutCheck/1/iterations:1000          3280 ns         3280 ns         1000
RegionBlockReaderBenchTest/CommonHandleWithoutCheck/10/iterations:1000         6541 ns         6541 ns         1000
RegionBlockReaderBenchTest/CommonHandleWithoutCheck/100/iterations:1000       35064 ns        35066 ns         1000
RegionBlockReaderBenchTest/PKIsNotHandleWithCheck/1/iterations:1000            3243 ns         3243 ns         1000
RegionBlockReaderBenchTest/PKIsNotHandleWithCheck/10/iterations:1000           5918 ns         5919 ns         1000
RegionBlockReaderBenchTest/PKIsNotHandleWithCheck/100/iterations:1000         32260 ns        32261 ns         1000
RegionBlockReaderBenchTest/PKIsNotHandleWithoutCheck/1/iterations:1000         3272 ns         3272 ns         1000
RegionBlockReaderBenchTest/PKIsNotHandleWithoutCheck/10/iterations:1000        5970 ns         5970 ns         1000
RegionBlockReaderBenchTest/PKIsNotHandleWithoutCheck/100/iterations:1000      32174 ns        32176 ns         1000
```
### Check List
